### PR TITLE
fix ng e2e on windows & remove need for npm run update on all platforms.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,9 +45,6 @@ jobs:
       - name: npm_install
         run: npm clean-install
         working-directory: ${{ env.WORKING_DIRECTORY }}
-      - name: npm_update
-        run: npm run update
-        working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: npm_test
         run: npm run test
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,9 +51,6 @@ jobs:
       - name: npm_install
         run: npm clean-install
         working-directory: ${{ env.WORKING_DIRECTORY }}
-      - name: npm_update
-        run: npm run update
-        working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: npm_test
         run: npm run test
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/angular/e2e/protractor.conf.js
+++ b/angular/e2e/protractor.conf.js
@@ -16,7 +16,8 @@ exports.config = {
     },
   },
   chromeDriver:
-    '../node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_80.0.3987.106',
+    '../node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_80.0.3987.106' +
+    (process.platform === 'win32' ? '.exe' : ''),
   directConnect: true,
   baseUrl: 'http://localhost:4200/',
   framework: 'jasmine',

--- a/angular/package.json
+++ b/angular/package.json
@@ -41,7 +41,7 @@
     "karma-sonarqube-unit-reporter": "0.0.21",
     "netlify-cli": "^2.50.0",
     "protractor": "~5.4.3",
-    "puppeteer": "^2.1.1",
+    "puppeteer": "~2.1.1",
     "sonarqube-scanner": "^2.6.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
@@ -54,6 +54,6 @@
     "lint": "ng lint",
     "start": "ng serve",
     "test": "ng test --code-coverage",
-    "update": "webdriver-manager update --versions.chrome 80.0.3987.106"
+    "postinstall": "webdriver-manager update --versions.chrome 80.0.3987.106 --standalone false --gecko false"
   }
 }


### PR DESCRIPTION
- On Windows, even after `npm run update`, `ng e2e` fails with a "Could not find chromedriver" error, due to a platform-dependent path issue. This resolves the issue by altering the protractor configuration based on [`process.platform`](https://nodejs.org/api/process.html#process_process_platform) (which is `'win32'` on any version of Windows). This fix was applied successfully in a [previous iteration](https://github.com/P3-Team-A/rvtr-app-campsite/blob/master/angular/e2e/protractor.conf.js) but never made it to master.

- NPM script "update" renamed to "postinstall" so it runs automatically. Added extra arguments to skip wasting time downloading gecko/standalone drivers.

- Puppeteer version range changed to lock down the minor version number, because that's the one they update when they change the bundled chromium version.