### PR TITLE
add ci workflow for non-master prs.

### DIFF
--- a/.github/workflows/local.yaml
+++ b/.github/workflows/local.yaml
@@ -91,8 +91,8 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: npm_scan
         run: npm run scan --
-          -Dsonar.organization=${{ github.event.organization }}
-          -Dsonar.projectKey=${{ github.event.organization }}_${{ github.event.repository.name }}
+          -Dsonar.organization=${{ github.event.pull_request.base.user.login }}
+          -Dsonar.projectKey=${{ github.event.pull_request.base.user.login }}_${{ github.event.pull_request.base.repo.name }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
 name: build

--- a/.github/workflows/local.yaml
+++ b/.github/workflows/local.yaml
@@ -1,0 +1,103 @@
+env:
+  CACHE_KEY_PREFIX: angular
+  WORKING_DIRECTORY: angular
+
+jobs:
+  build:
+    env:
+      SENTRY_DRY_RUN: true
+    name: build_angular
+    runs-on: ubuntu-18.04
+    steps:
+      - name: actions_checkout
+        uses: actions/checkout@v2.1.0
+      - name: npm_cache
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.npm
+          key: ${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('**/package-lock.json') }}
+      - name: npm_install
+        run: npm clean-install
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: npm_lint
+        run: npm run lint
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: npm_build
+        run: npm run build
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: drop_upload
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: drop
+          path: ${{ env.WORKING_DIRECTORY }}/dist/rvtr-app-campsite
+
+  test:
+    name: test_angular
+    runs-on: ubuntu-18.04
+    steps:
+      - name: actions_checkout
+        uses: actions/checkout@v2.1.0
+      - name: npm_cache
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.npm
+          key: ${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('**/package-lock.json') }}
+      - name: npm_install
+        run: npm clean-install
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: npm_test
+        run: npm run test
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: npm_e2e
+        run: npm run e2e
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: lcov_upload
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: code_coverage
+          path: ${{ env.WORKING_DIRECTORY }}/code_coverage
+      - name: report_upload
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: test_coverage
+          path: ${{ env.WORKING_DIRECTORY }}/test_coverage
+
+  analyze:
+    name: analyze_angular
+    needs: [build, test]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: actions_checkout
+        uses: actions/checkout@v2.1.0
+      - name: git_fetch
+        run: git fetch --unshallow
+      - name: lcov_download
+        uses: actions/download-artifact@v1.0.0
+        with:
+          name: code_coverage
+          path: ${{ env.WORKING_DIRECTORY }}/code_coverage
+      - name: report_download
+        uses: actions/download-artifact@v1.0.0
+        with:
+          name: test_coverage
+          path: ${{ env.WORKING_DIRECTORY }}/test_coverage
+      - name: npm_cache
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.npm
+          key: ${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('**/package-lock.json') }}
+      - name: npm_install
+        run: npm clean-install
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - name: npm_scan
+        run: npm run scan --
+          -Dsonar.organization=${{ github.event.organization }}
+          -Dsonar.projectKey=${{ github.event.organization }}_${{ github.event.repository.name }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+name: build
+
+on:
+  pull_request:
+    branches-ignore:
+      - master


### PR DESCRIPTION
the differences in this file from build.yaml is
1. on line 102, `branches-ignore`
2. on lines 93-95, providing key and org from the ci environment, overriding the .properties file. (so it works for prs in other repos)